### PR TITLE
fix problem with client not able to run koji commands 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Now, if you have the Koji client RPM installed locally, you can start using the 
 koji -c /opt/koji-clients/testuser/config hello
 ```
 
+```
+koji -c /opt/koji-clients/testuser/config list-tags
+```
+
+
 ## Client Image Notes
 
 The client container mounts all exposed volumes from the hub. During initialization, it installs the Koji client RPM in `/opt/koji/noarch` (built by the hub during its own initialization), then uses the SSL configurations under `/opt/koji-clients` to generate `/root/.koji/config` with headings like `koji-testuser`. Next it symlinks `/usr/local/koji` to corresponding script names (eg. `koji-testuser`) under `/root/bin`.

--- a/hub/bin/mkuser.sh
+++ b/hub/bin/mkuser.sh
@@ -40,7 +40,7 @@ openssl req -config $conf -new -nodes -out certs/${user}.csr -key private/${user
 openssl ca -config $conf -batch -keyfile private/${caname}_ca_cert.key -cert ${caname}_ca_cert.crt \
 		   -out certs/${user}-crtonly.crt -outdir certs -infiles certs/${user}.csr
 
-openssl pkcs12 -export -inkey private/${user}.key -passout "pass:${password}" -in certs/${user}-crtonly.crt -CAfile ${caname}_ca_cert.crt \
+openssl pkcs12 -export -inkey private/${user}.key -passout "pass:${password}" -in certs/${user}-crtonly.crt -certfile ${caname}_ca_cert.crt -CAfile ${caname}_ca_cert.crt -chain -clcerts \
 			   -out certs/${user}_browser_cert.p12
 
 openssl pkcs12 -clcerts -passin "pass:${password}" -passout "pass:${password}" -in certs/${user}_browser_cert.p12 -inkey private/${user}.key -out certs/${user}.pem

--- a/hub/bin/mkuser.sh
+++ b/hub/bin/mkuser.sh
@@ -49,6 +49,7 @@ cat certs/${user}-crtonly.crt private/${user}.key > certs/${user}.crt
 
 client=/opt/koji-clients/${user}
 
+rm -rf $client
 mkdir -p $client
 cp /etc/pki/koji/certs/${user}.crt $client/client.crt   # NOTE: It is IMPORTANT you use the aggregated form
 cp /etc/pki/koji/certs/${user}.pem $client/client.pem

--- a/hub/bin/setup.sh
+++ b/hub/bin/setup.sh
@@ -44,12 +44,11 @@ generate_ssl_certificates() {
 	cp private/koji_ca_cert.key private/kojihub.key
 	cp koji_ca_cert.crt certs/kojihub.crt
 
-	rm -rf /koji-clients/*
-
 	mkuser.sh kojiweb admin
 	mkuser.sh kojiadmin admin
 	mkuser.sh testadmin admin
 	mkuser.sh testuser
+
 	chown -R nobody:nobody /opt/koji-clients
 }
 

--- a/hub/bin/setup.sh
+++ b/hub/bin/setup.sh
@@ -35,13 +35,10 @@ generate_ssl_certificates() {
 	echo 01 > serial
 
 	# CA
-	openssl genrsa -out private/koji_ca_cert.key 2048
-
-	CA_SAN="IP.1:${IP},DNS.1:localhost,DNS.2:${IP}"
 	conf=confs/ca.cnf
+	cp ssl.cnf $conf
 
-	cat ssl.cnf | sed "s/email\:copy/${CA_SAN}/"> $conf
-
+	openssl genrsa -out private/koji_ca_cert.key 2048
 	openssl req -config $conf -new -x509 -subj "/C=US/ST=Drunken/L=Bed/O=IT/CN=koji-hub" -days 3650 -key private/koji_ca_cert.key -out koji_ca_cert.crt -extensions v3_ca
 
 	cp private/koji_ca_cert.key private/kojihub.key

--- a/hub/etc/httpd/conf.d/kojihub.conf
+++ b/hub/etc/httpd/conf.d/kojihub.conf
@@ -38,7 +38,7 @@ Alias /kojifiles "/mnt/koji/"
 # uncomment this to enable authentication via SSL client certificates
 <Location /kojihub/ssllogin>
     SSLVerifyClient require
-    SSLVerifyDepth  10
+    SSLVerifyDepth  1
     SSLOptions +StdEnvVars
 </Location>
 

--- a/hub/etc/httpd/conf.d/ssl.conf
+++ b/hub/etc/httpd/conf.d/ssl.conf
@@ -139,8 +139,7 @@ SSLCertificateFile /etc/pki/koji/certs/kojihub.crt
 SSLCertificateKeyFile /etc/pki/koji/private/kojihub.key
 SSLCertificateChainFile /etc/pki/koji/koji_ca_cert.crt
 SSLCACertificateFile /etc/pki/koji/koji_ca_cert.crt
-SSLVerifyClient require
-SSLVerifyDepth  10
+SSLVerifyDepth  1
 
 #   Access Control:
 #   With SSLRequire you can do per-directory access control based

--- a/hub/etc/koji-hub/hub.conf
+++ b/hub/etc/koji-hub/hub.conf
@@ -95,5 +95,5 @@ EnableWin = True
 KojiDebug = On
 KojiTraceback = extended
 DNUsernameComponent = CN
-ProxyDNs = /C=US/ST=Drunken/O=IT/CN=kojiweb/emailAddress=kojiweb@kojihub.local
+ProxyDNs = /C=US/ST=Drunken/O=IT/CN=kojiweb
 

--- a/hub/etc/pki/koji/ssl.cnf
+++ b/hub/etc/pki/koji/ssl.cnf
@@ -67,10 +67,10 @@ basicConstraints                = CA:FALSE
 nsComment                       = "OpenSSL Generated Certificate"
 subjectKeyIdentifier            = hash
 authorityKeyIdentifier          = keyid,issuer:always
-subjectAltName                  = email:copy
+subjectAltName                  = email:move
 
 [v3_ca] 
 subjectKeyIdentifier            = hash
 authorityKeyIdentifier          = keyid:always,issuer:always
 basicConstraints                = CA:true
-subjectAltName                  = email:copy
+subjectAltName                  = email:move


### PR DESCRIPTION
problem was caused by ssl configuration allowing connections to hub only with client SSL certifacate for every location instead of only for login