### PR TITLE
restore subjectAltNames IP address and use dev tag for built images

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for c in hub client; do
+for c in hub client builder; do
 	echo "Building $c"
 	${c}/docker-scripts/build.sh
 done

--- a/builder/docker-scripts/build.sh
+++ b/builder/docker-scripts/build.sh
@@ -2,4 +2,5 @@
 
 DIR=$(dirname $(dirname $(realpath $0)))
 
-docker build --tag=docker.io/buildchimp/koji-dojo-builder $DIR
+set -x
+docker build --tag=docker.io/buildchimp/koji-dojo-builder:dev $DIR

--- a/client/docker-scripts/build.sh
+++ b/client/docker-scripts/build.sh
@@ -2,4 +2,5 @@
 
 DIR=$(dirname $(dirname $(realpath $0)))
 
-docker build --tag=docker.io/buildchimp/koji-dojo-client $DIR
+set -x
+docker build --tag=docker.io/buildchimp/koji-dojo-client:dev $DIR

--- a/hub/bin/setup.sh
+++ b/hub/bin/setup.sh
@@ -41,7 +41,9 @@ generate_ssl_certificates() {
 
 	# CA
 	conf=confs/ca.cnf
-	cp ssl.cnf $conf
+	CA_SAN="IP.1:${IP},DNS.1:localhost,DNS.2:${IP},email:move"
+ 
+	cat ssl.cnf | sed "s/email\:move/${CA_SAN}/"> $conf	cp ssl.cnf $conf
 
 	openssl genrsa -out private/koji_ca_cert.key 2048
 	openssl req -config $conf -new -x509 -subj "/C=US/ST=Drunken/L=Bed/O=IT/CN=koji-hub" -days 3650 -key private/koji_ca_cert.key -out koji_ca_cert.crt -extensions v3_ca

--- a/hub/docker-scripts/build.sh
+++ b/hub/docker-scripts/build.sh
@@ -2,4 +2,5 @@
 
 DIR=$(dirname $(dirname $(realpath $0)))
 
-docker build --tag=docker.io/buildchimp/koji-dojo-hub $DIR
+set -x
+docker build --tag=docker.io/buildchimp/koji-dojo-hub:dev $DIR

--- a/push-all.sh
+++ b/push-all.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 docker login -u buildchimp
-for c in docker.io/buildchimp/koji-dojo-hub docker.io/buildchimp/koji-dojo-client; do
-	dev="${c}:dev"
-	echo "Renaming $c with :dev tag"
-	docker tag -f $c $dev
-
-	echo "Pushing: $dev"
-	docker push $dev
+for c in docker.io/buildchimp/koji-dojo-hub:dev docker.io/buildchimp/koji-dojo-client:dev docker.io/buildchimp/koji-dojo-builder:dev; do
+	echo "Pushing: $c"
+	docker push $c
 done

--- a/research/build-init/relevant-koji-snippets.py
+++ b/research/build-init/relevant-koji-snippets.py
@@ -93,3 +93,12 @@ koji/__init__.py@1040:
            'epoch': None}
     # for backwards-compatibility
     nvr['package_name'] = nvr['name']
+
+kojihub.py@8182:
+
+ def makeTask(self,*args,**opts):
+        #this is mainly for debugging
+        #only an admin can make arbitrary tasks
+        context.session.assertPerm('admin')
+        return make_task(*args,**opts)
+


### PR DESCRIPTION
subjectAltNames with IP address are required for using these images as test appliances in CI builds of things like release-engineering/kojiji.