### PR TITLE
Set docker volume labels as shared volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ koji-hub:
     build: hub
     hostname: koji-hub
     volumes:
-        - /opt/koji:/opt/koji:rw
-        - /opt/koji-clients:/opt/koji-clients:rw
+        - /opt/koji:/opt/koji:rw,z
+        - /opt/koji-clients:/opt/koji-clients:rw,z
     links:
         - koji-db
 


### PR DESCRIPTION
Fixes "permission denied" SELinux fcontext issues from #19

Works from scratch with no preexisting directories or selinux rules on /opt/koji\* needed.
Tested under Fedora 25, Docker 1.12.2

Ref:
https://docs.docker.com/engine/tutorials/dockervolumes/#/volume-labels
http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
