### PR TITLE
Selinux and dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ koji-hub:
     build: hub
     hostname: koji-hub
     volumes:
-        - /opt/koji:/opt/koji:rw
-        - /opt/koji-clients:/opt/koji-clients:rw
+        - /opt/koji:/opt/koji:rw,z
+        - /opt/koji-clients:/opt/koji-clients:rw,z
     links:
         - koji-db
 

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -7,6 +7,7 @@ RUN sed -i '/nodocs/d' /etc/yum.conf
 VOLUME ["/opt/koji-clients", "/opt/koji"]
 
 RUN yum -y update && \
+    yum install -y http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && \
     yum -y install \
         git \
         yum-utils \


### PR DESCRIPTION
Selinux is described here: https://github.com/release-engineering/koji-dojo/issues/19 (tested on Fedora 25). NOT my fix...

Package koji-hub-plugins needs python-qpid-proton from epel, so I added epel release to hub's Dockerfile.