### PR TITLE
unify epel-release installation

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -5,10 +5,7 @@ MAINTAINER John Casey <jcasey@redhat.com>
 RUN sed -i '/nodocs/d' /etc/yum.conf
 
 RUN yum -y update && \
-    yum -y install wget && \
-    wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && \
-    yum -y install epel-release-latest-6.noarch.rpm && \
-    rm epel-release-latest-6.noarch.rpm && \
+    yum -y install wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && \
     yum -y install \
         lsof \
         python-simplejson \

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -7,7 +7,7 @@ RUN sed -i '/nodocs/d' /etc/yum.conf
 VOLUME ["/opt/koji-clients", "/opt/koji"]
 
 RUN yum -y update && \
-    yum install -y http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm && \
+    yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm && \
     yum -y install \
         git \
         yum-utils \


### PR DESCRIPTION
Use more generic rpm from https://fedoraproject.org/wiki/EPEL docs in both builder and hub images.