### PR TITLE
Simplify the command interface of Vagrant wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,25 +180,60 @@ kojitest maven-build build-target https://www.github.com/myorg/myproject
 
 ## Vagrant wrapper for koji-dojo
 
-You can install Koji-Dojo inside a Vagrant VM.
+The `./Vagrantfile` enables you to install and run Koji-Dojo inside a Vagrant VM.
 
 The pre-requisite is Vagrant with libvirt provider installed on the workstation.
 
-```
-# First-time execution
-vagrant up
-# - which will provision both the Vagrant VM and koji-dojo Docker containers inside it
+### Usage example
 
-vagrant ssh -c 'sudo make -C /vagrant run' # will start the Docker containers and leave koji-builder running interactively
+~~~~
+# Provision both the Vagrant VM and koji-dojo Docker containers inside it
+$ vagrant up
 
-# ...and while it's running, in a separate console
-vagrant ssh -c 'sudo make -C /vagrant sources rpm-scratch-build'
-# - which will apply a patch to Koji which makes 'import-comps' command work, and then run a demo Koji task
+# Run a sample Koji build
+$ make demo-build
 
-# Map Koji UI host/port to the Vagrant host VM. This makes Koji UI available on http://localhost:4433/koji
-ssh localhost -L*:4433:172.17.0.3:443
+# Review build results
+$ vagrant ssh -c 'tree /opt/koji-files/scratch'
+/opt/koji-files/scratch
+└── kojiadmin
+    └── task_3
+        ├── koji-1.11.0-5.fc25.noarch.rpm
+        ├── koji-1.11.0-5.fc25.src.rpm
+        ├── koji-builder-1.11.0-5.fc25.noarch.rpm
+        ├── koji-hub-1.11.0-5.fc25.noarch.rpm
+        ├── koji-hub-plugins-1.11.0-5.fc25.noarch.rpm
+        ├── koji-utils-1.11.0-5.fc25.noarch.rpm
+        ├── koji-vm-1.11.0-5.fc25.noarch.rpm
+        ├── koji-web-1.11.0-5.fc25.noarch.rpm
+        └── logs
+            └── noarch
+                ├── build.log
+                ├── mock_output.log
+                ├── root.log
+                └── state.log
+
 
 # Drop the Vagrant VM to try again:
-vagrant destroy -f && vagrant up
-# ... and continue from the beginning
-```
+$ vagrant destroy -f && vagrant up && make demo-build
+
+~~~~
+
+### How to access Koji Web
+
+Use SSH port forwarding to get access to Koji web that is running in Vagrant guest VM. 
+
+`vagrant ssh -c 'ssh localhost -L*:4433:172.17.0.3:443'`
+
+- this makes Koji UI available on http://localhost:4433/koji
+
+### How to login to a Docker container
+
+~~~~
+# login to the builder container
+make enter container=koji-builder
+
+# login to the hub (by default)
+make enter
+
+~~~~

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,14 +64,5 @@ Vagrant.configure(2) do |config|
     sed -i 's/SELINUX=.*/SELINUX=disabled/' /etc/selinux/config 
   SHELL
   config.vm.provision :reload
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo dnf -y install docker make koji wget patch
-    sudo systemctl enable docker
-    sudo systemctl start docker
-    sudo mkdir -p /opt/koji-files
-    sudo chmod 777 -R /opt/koji-files
-    sudo make -C /vagrant build
-    sudo dnf -y install rpm-build
-  SHELL
-
+  config.vm.provision "shell", path:'./start-containers.sh'
 end

--- a/start-containers.sh
+++ b/start-containers.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Install and configure Docker on Vagrant guest VM.
+# Start Koji-Dojo containers.
+
+dnf -y install make docker koji wget patch tree rpm-build
+systemctl enable docker
+systemctl start docker
+
+# Allow Koji to use Fedora repos
+sed -i 's|^allowed_scms.*|allowed_scms=src.fedoraproject.org:/*:no  \
+    pkgs.fedoraproject.org:/*:no:fedpkg,sources|' \
+    /vagrant/builder/bin/entrypoint.sh
+
+mkdir -p /opt/koji-files
+chmod 777 -R /opt/koji-files
+
+# Build and start koji-dojo containers
+cd /vagrant/builder/docker-scripts
+./build-all.sh
+./run-all.sh -d
+echo "Koji Docker containers are started"
+kojiconfig=/opt/koji-clients/kojiadmin/config 
+test -f $kojiconfig || \
+    echo Waiting for koji-hub to initialize configuration files... ;\
+    until test -f $kojiconfig ; do printf . ; sleep 2 ; done
+sleep 4; echo .. done

--- a/vagrant-guest.mk
+++ b/vagrant-guest.mk
@@ -1,0 +1,21 @@
+# A set of Makefile targets that is to be run inside Vagrant quest VM
+
+.PHONY: clean sources rpm-scratch-build
+
+# Remove koji-dojo Docker containers and images; cleanup build directories
+clean:
+	docker rm -f koji-hub koji-db koji-builder
+	printf "Attempted to drop existing containers, ignoring the missing ones.\nDone\n"
+	docker images | grep '^docker.io/buildchimp/koji-dojo-' \
+	| awk '{ print $$3 }' | xargs docker rmi
+	rm -rf /opt/koji-files/[prsw]*
+
+# Apply a critical patch that isn't yet in the master branch
+sources:
+	patch -f -d /usr/bin < ./patches/koji-pr-307.patch ; echo;
+	printf "Attempted to patch koji, skipping possible 'Already patched' errors\nDone\n"
+
+# Congigure Koji tags and repos then run a sample scratch build task
+rpm-scratch-build: scratchbuild ?= ./buildroot/fedora-25-noarch
+rpm-scratch-build:
+	$(scratchbuild)


### PR DESCRIPTION
Added Makefile targets for logging into containers and accessing Koji
database. Moved Shell provisioning commands from `./Vagrantfile` to a
separate Shell script. Changed the way user specifies buildroot
parameter. Moved the Makefile targets intended for running inside
Vagrant VM to a separate Makefile `./vagrant-guest.mk`