### PR TITLE
Updates to track new changes in koji

### DIFF
--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -24,6 +24,13 @@ RUN yum -y update && \
         python-simplejson \
         PyGreSQL \
         pyOpenSSL \
+        python-backports \
+        python-backports-ssl_match_hostname \
+        python-cheetah \
+        python-coverage \
+        python-dateutil \
+        python-devel \
+        python-kerberos \
         python-krbV \
         python-qpid \
         python-saslwrapper \

--- a/hub/bin/build-koji.sh
+++ b/hub/bin/build-koji.sh
@@ -22,7 +22,7 @@ cd /opt/koji
 rm -rf noarch
 make test-rpm
 
-yum -y localinstall noarch/koji-hub*.rpm noarch/koji-1.*.rpm noarch/koji-web*.rpm
+yum -y localinstall noarch/koji-hub*.rpm noarch/koji-1.*.rpm noarch/koji-web*.rpm noarch/python2-koji*.rpm
 
 echo "Sleep 10s in case database container is still booting..."
 sleep 10

--- a/hub/bin/entrypoint.sh
+++ b/hub/bin/entrypoint.sh
@@ -8,8 +8,8 @@ if grep -q -v "koji-db" /etc/hosts; then
     echo ${KOJI_DB_IP} koji-db >> /etc/hosts
 fi
 
-build-koji.sh
-setup.sh
+build-koji.sh || exit 1
+setup.sh || exit 2
 
 IP=$(find-ip.py)
 

--- a/hub/cgi/setup.py
+++ b/hub/cgi/setup.py
@@ -61,7 +61,7 @@ else:
   output = ''
 
   sys.stderr.write("Executing temp script: %s" % script.name)
-  process = subprocess.Popen(['/usr/bin/sudo', '/bin/sh', script.name], stdout=subprocess.PIPE, shell=False)
+  process = subprocess.Popen(['/usr/bin/sudo', '/bin/sh', script.name, '2>&1'], stdout=subprocess.PIPE, shell=False)
   output, _err = process.communicate()
 
   retcode = process.poll()


### PR DESCRIPTION
Adding python-devel to Dockerfile since this is now required. Adding
python2-koji* to list of rpms to localinstall in the build-koji.sh
script. Making setup.py a little more friendly by piping stderr over
stdout. Finally, make entrypoint exit if build-koji.sh or setup.sh
fail.

Conflicts:
	hub/Dockerfile